### PR TITLE
Removes topic echo from publisher.bash

### DIFF
--- a/scripts/publisher.bash
+++ b/scripts/publisher.bash
@@ -2,4 +2,5 @@
 . /ros/install/setup.bash
 echo "Discovery setting is $ROS_AUTOMATIC_DISCOVERY_RANGE, scenario is ${RES_DIR}"
 
-ros2 topic pub -t 10 --max-wait-time 5 /test_topic std_msgs/String "data: Hello" & ros2 topic echo --timeout 10 --once /test_topic std_msgs/String > /results/publisher
+ros2 topic pub -t 10 --max-wait-time 5 /test_topic std_msgs/String "data: Hello"  > /results/publisher
+#& ros2 topic echo --timeout 10 --once /test_topic std_msgs/String > /results/publisher


### PR DESCRIPTION
Rationale:
1. We don't actually check publisher.bash in `report_gen.py`.
2. The publihser will ony wait for one connection. Often this connection witll be the echo coming from the same host. Hence test benchmarks will be flakly wrt other hosts.